### PR TITLE
Fix the name of the plugin in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Purge build queue plugin
+Console Column plugin
 ==============================
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/console-column-plugin/master)](https://ci.jenkins.io/job/plugins/job/console-column-plugin/)
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/console-column-plugin.svg)](https://plugins.jenkins.io/console-column-plugin/)


### PR DESCRIPTION
Simple copy & paste error, I guess.
