### PR TITLE
Upgrade the Jenkins baseline from 2.361.x to 2.387.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,14 +84,14 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.387.3</jenkins.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
+        <artifactId>bom-2.387.x</artifactId>
         <version>2102.v854b_fec19c92</version>
         <scope>import</scope>
         <type>pom</type>


### PR DESCRIPTION
_This is an autogenerated PR for updating the Jenkins baseline._

Jenkins 2.361.x is subject to [seven](https://www.jenkins.io/security/advisory/2023-03-08/) security vulnerabilities coming from Jenkins itself, and has been removed from the Jenkins BOM.
2.387.x is the second-oldest baseline and has no unresolved security vulnerabilities.

Ping @NotMyFault if you have questions.

_[script source](https://github.com/NotMyFault/jenkins-version-updater)_
